### PR TITLE
docs: Fix a few typos

### DIFF
--- a/codebreaker_unit_tests.py
+++ b/codebreaker_unit_tests.py
@@ -17,7 +17,7 @@ import unittest, subprocess, pyperclip, hashlib, os, sys, io, random, shutil
 # @c:\Python32\python.exe c:\Python32\Lib\site-packages\pylint\lint.py --rcfile=pylint.conf %1 %2 %3 %4 %5 %6 %7 %8 %9
 #
 # This way I could run "run_pylint.bat foo.py" to run pylint on a source code file.
-# Be sure to download the pylint.conf config file and have it in the same folderas codebreaker_unit_tests.py
+# Be sure to download the pylint.conf config file and have it in the same folders codebreaker_unit_tests.py
 
 
 FOX_MESSAGE = "The quick brown fox jumped over the yellow lazy dog.".upper()

--- a/codebreaker_unit_tests.py
+++ b/codebreaker_unit_tests.py
@@ -17,7 +17,7 @@ import unittest, subprocess, pyperclip, hashlib, os, sys, io, random, shutil
 # @c:\Python32\python.exe c:\Python32\Lib\site-packages\pylint\lint.py --rcfile=pylint.conf %1 %2 %3 %4 %5 %6 %7 %8 %9
 #
 # This way I could run "run_pylint.bat foo.py" to run pylint on a source code file.
-# Be sure to download the pylint.conf config file and have it in the same folders codebreaker_unit_tests.py
+# Be sure to download the pylint.conf config file and have it in the same folder as codebreaker_unit_tests.py
 
 
 FOX_MESSAGE = "The quick brown fox jumped over the yellow lazy dog.".upper()

--- a/freqFinder.py
+++ b/freqFinder.py
@@ -17,7 +17,7 @@ def getLetterCount(message):
     # count of how many times they appear in the message parameter.
     letterToCount = {}
     for letter in LETTERS:
-        letterToCount[letter] = 0 # intialize each letter to 0
+        letterToCount[letter] = 0 # initialize each letter to 0
 
     for letter in message:
         if letter in LETTERS:


### PR DESCRIPTION
There are small typos in:
- codebreaker_unit_tests.py
- freqFinder.py

Fixes:
- Should read `initialize` rather than `intialize`.
- Should read `folders` rather than `folder as`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md